### PR TITLE
Add --base-url flag for connector testability

### DIFF
--- a/pkg/config/conf.gen.go
+++ b/pkg/config/conf.gen.go
@@ -11,6 +11,7 @@ type Outreach struct {
 	Oauth2 string `mapstructure:"oauth2"`
 	Oauth2ClientId string `mapstructure:"oauth2-client-id"`
 	Oauth2ClientSecret string `mapstructure:"oauth2-client-secret"`
+	BaseUrl string `mapstructure:"base-url"`
 }
 
 func (c *Outreach) findFieldByTag(tagValue string) (any, bool) {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -14,6 +14,7 @@ var (
 
 	BaseURLField = field.StringField("base-url",
 		field.WithDescription("Override the Outreach API URL (for testing)"),
+		field.WithHidden(true),
 	)
 
 	accessTokenField = field.StringField("access-token",

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -12,6 +12,10 @@ var (
 	// that will refresh automatically the access token when expired.
 	// Those flags should be used when executing the connector on the CLI in service mode.
 
+	BaseURLField = field.StringField("base-url",
+		field.WithDescription("Override the Outreach API URL (for testing)"),
+	)
+
 	accessTokenField = field.StringField("access-token",
 		field.WithDisplayName("Access Token"),
 		field.WithDescription("Generated access token to communicate with Outreach API. Only for CLI one-shot executions."),
@@ -71,6 +75,8 @@ var (
 		oauth2TokenField,
 		oauth2ClientIdField,
 		oauth2ClientSecretField,
+
+		BaseURLField,
 	}
 
 	// FieldRelationships defines relationships between the ConfigurationFields that can be automatically validated.

--- a/pkg/connector/actions.go
+++ b/pkg/connector/actions.go
@@ -17,6 +17,7 @@ import (
 const (
 	ActionEnableUser  = "enable_user"
 	ActionDisableUser = "disable_user"
+	successKey        = "success"
 )
 
 var enableUserAction = &v2.BatonActionSchema{
@@ -31,7 +32,7 @@ var enableUserAction = &v2.BatonActionSchema{
 	},
 	ReturnTypes: []*config.Field{
 		{
-			Name:        "success",
+			Name:        successKey,
 			DisplayName: "Success",
 			Field:       &config.Field_BoolField{},
 		},
@@ -53,7 +54,7 @@ var disableUserAction = &v2.BatonActionSchema{
 	},
 	ReturnTypes: []*config.Field{
 		{
-			Name:        "success",
+			Name:        successKey,
 			DisplayName: "Success",
 			Field:       &config.Field_BoolField{},
 		},
@@ -125,7 +126,7 @@ func (c *Connector) setUserState(ctx context.Context, args *structpb.Struct, ena
 		l.Warn("user enable operation completed but user is still locked", zap.String("user_id", userIDStr))
 		result := &structpb.Struct{
 			Fields: map[string]*structpb.Value{
-				"success": structpb.NewBoolValue(false),
+				successKey: structpb.NewBoolValue(false),
 			},
 		}
 		return result, annos, nil
@@ -134,7 +135,7 @@ func (c *Connector) setUserState(ctx context.Context, args *structpb.Struct, ena
 		l.Warn("user disable operation completed but user is still unlocked", zap.String("user_id", userIDStr))
 		result := &structpb.Struct{
 			Fields: map[string]*structpb.Value{
-				"success": structpb.NewBoolValue(false),
+				successKey: structpb.NewBoolValue(false),
 			},
 		}
 		return result, annos, nil
@@ -142,7 +143,7 @@ func (c *Connector) setUserState(ctx context.Context, args *structpb.Struct, ena
 
 	result := &structpb.Struct{
 		Fields: map[string]*structpb.Value{
-			"success": structpb.NewBoolValue(true),
+			successKey: structpb.NewBoolValue(true),
 		},
 	}
 

--- a/pkg/connector/client/client.go
+++ b/pkg/connector/client/client.go
@@ -13,16 +13,17 @@ import (
 )
 
 const (
-	authURL    = "https://api.outreach.io/oauth/token"
-	baseURL    = "https://api.outreach.io/api/v2"
-	usersEP    = "users"
-	teamsEP    = "teams"
-	profilesEP = "profiles"
+	authURL        = "https://api.outreach.io/oauth/token"
+	DefaultBaseURL = "https://api.outreach.io/api/v2"
+	usersEP        = "users"
+	teamsEP        = "teams"
+	profilesEP     = "profiles"
 )
 
 type OutreachClient struct {
 	client      *uhttp.BaseHttpClient
 	TokenSource oauth2.TokenSource
+	baseURL     string
 }
 
 func (c *OutreachClient) ListAllUsers(ctx context.Context, nextPageLink string) ([]*User, string, *v2.RateLimitDescription, error) {
@@ -35,7 +36,7 @@ func (c *OutreachClient) ListAllUsers(ctx context.Context, nextPageLink string) 
 	if nextPageLink != "" {
 		requestURL = nextPageLink
 	} else {
-		usersURL, err := url.JoinPath(baseURL, usersEP)
+		usersURL, err := url.JoinPath(c.baseURL, usersEP)
 		if err != nil {
 			return nil, "", nil, err
 		}
@@ -71,7 +72,7 @@ func (c *OutreachClient) GetUserByID(ctx context.Context, userID string) (*User,
 		User *User `json:"data"`
 	}
 
-	userURL, err := url.JoinPath(baseURL, usersEP, userID)
+	userURL, err := url.JoinPath(c.baseURL, usersEP, userID)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -119,7 +120,7 @@ func (c *OutreachClient) UpdateUserProfile(ctx context.Context, userID string, p
 		},
 	}
 
-	userURL, err := url.JoinPath(baseURL, usersEP, userID)
+	userURL, err := url.JoinPath(c.baseURL, usersEP, userID)
 	if err != nil {
 		return nil, err
 	}
@@ -171,7 +172,7 @@ func (c *OutreachClient) SetUserLocked(ctx context.Context, userID string, locke
 		},
 	}
 
-	userURL, err := url.JoinPath(baseURL, usersEP, userID)
+	userURL, err := url.JoinPath(c.baseURL, usersEP, userID)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -197,7 +198,7 @@ func (c *OutreachClient) CreateUser(ctx context.Context, newUserInfo NewUserBody
 		User *User `json:"data"`
 	}
 
-	userURL, err := url.JoinPath(baseURL, usersEP)
+	userURL, err := url.JoinPath(c.baseURL, usersEP)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -228,7 +229,7 @@ func (c *OutreachClient) ListAllTeams(ctx context.Context, nextPageLink string) 
 	if nextPageLink != "" {
 		requestURL = nextPageLink
 	} else {
-		teamsURL, err := url.JoinPath(baseURL, teamsEP)
+		teamsURL, err := url.JoinPath(c.baseURL, teamsEP)
 		if err != nil {
 			return nil, "", nil, err
 		}
@@ -264,7 +265,7 @@ func (c *OutreachClient) GetTeamByID(ctx context.Context, teamID string) (*Team,
 		Team *Team `json:"data"`
 	}
 
-	teamURL, err := url.JoinPath(baseURL, teamsEP, teamID)
+	teamURL, err := url.JoinPath(c.baseURL, teamsEP, teamID)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -295,7 +296,7 @@ func (c *OutreachClient) ListAllProfiles(ctx context.Context, nextPageLink strin
 	if nextPageLink != "" {
 		requestURL = nextPageLink
 	} else {
-		rolesURL, err := url.JoinPath(baseURL, profilesEP)
+		rolesURL, err := url.JoinPath(c.baseURL, profilesEP)
 		if err != nil {
 			return nil, "", nil, err
 		}
@@ -348,7 +349,7 @@ func (c *OutreachClient) UpdateTeamMembers(ctx context.Context, teamID string, t
 		},
 	}
 
-	teamURL, err := url.JoinPath(baseURL, teamsEP, teamID)
+	teamURL, err := url.JoinPath(c.baseURL, teamsEP, teamID)
 	if err != nil {
 		return nil, err
 	}
@@ -454,7 +455,8 @@ func New(ctx context.Context, cOpts ...ConfigOption) (*OutreachClient, error) {
 	}
 
 	icClient := OutreachClient{
-		client: cli,
+		client:  cli,
+		baseURL: DefaultBaseURL,
 	}
 	for _, option := range cOpts {
 		option(&icClient)

--- a/pkg/connector/client/helper.go
+++ b/pkg/connector/client/helper.go
@@ -82,6 +82,14 @@ func WithAccessToken(accessToken string) ConfigOption {
 	}
 }
 
+func WithBaseURL(baseURL string) ConfigOption {
+	return func(client *OutreachClient) {
+		if baseURL != "" {
+			client.baseURL = baseURL
+		}
+	}
+}
+
 type ErrorResponse struct {
 	Error       string `json:"error"`
 	Description string `json:"description"`

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -74,8 +74,8 @@ func (d *Connector) Validate(_ context.Context) (annotations.Annotations, error)
 }
 
 // NewWithAccessToken returns a new instance of the connector created for CLI one-shot executions.
-func NewWithAccessToken(ctx context.Context, accessToken string) (*Connector, error) {
-	c, err := client.New(ctx, client.WithAccessToken(accessToken))
+func NewWithAccessToken(ctx context.Context, accessToken, baseURL string) (*Connector, error) {
+	c, err := client.New(ctx, client.WithAccessToken(accessToken), client.WithBaseURL(baseURL))
 	if err != nil {
 		return nil, err
 	}
@@ -86,8 +86,8 @@ func NewWithAccessToken(ctx context.Context, accessToken string) (*Connector, er
 }
 
 // NewWithRefreshToken returns a new instance of the connector created for CLI with automatic token refresh.
-func NewWithRefreshToken(ctx context.Context, clientID, clientSecret, refreshToken string) (*Connector, error) {
-	c, err := client.New(ctx, client.WithRefreshToken(ctx, clientID, clientSecret, refreshToken))
+func NewWithRefreshToken(ctx context.Context, clientID, clientSecret, refreshToken, baseURL string) (*Connector, error) {
+	c, err := client.New(ctx, client.WithRefreshToken(ctx, clientID, clientSecret, refreshToken), client.WithBaseURL(baseURL))
 	if err != nil {
 		return nil, err
 	}
@@ -98,9 +98,10 @@ func NewWithRefreshToken(ctx context.Context, clientID, clientSecret, refreshTok
 }
 
 // NewWithTokenSource returns a new instance of the connector using a provided Token Source.
-func NewWithTokenSource(ctx context.Context, tokenSource oauth2.TokenSource) (*Connector, error) {
+func NewWithTokenSource(ctx context.Context, tokenSource oauth2.TokenSource, baseURL string) (*Connector, error) {
 	clientOptions := []client.ConfigOption{
 		client.WithTokenSource(tokenSource),
+		client.WithBaseURL(baseURL),
 	}
 
 	c, err := client.New(ctx, clientOptions...)
@@ -118,9 +119,11 @@ func New(ctx context.Context, config *cfg.Outreach, opts *cli.ConnectorOpts) (co
 	var cb *Connector
 	l := ctxzap.Extract(ctx)
 
+	baseURL := config.BaseUrl
+
 	accessToken := config.AccessToken
 	if accessToken != "" {
-		cbWithAccessToken, err := NewWithAccessToken(ctx, accessToken)
+		cbWithAccessToken, err := NewWithAccessToken(ctx, accessToken, baseURL)
 		if err != nil {
 			l.Error("error creating connector with access token", zap.Error(err))
 			return nil, nil, err
@@ -134,7 +137,7 @@ func New(ctx context.Context, config *cfg.Outreach, opts *cli.ConnectorOpts) (co
 	outreachClientSecret := config.OutreachClientSecret
 
 	if outreachClientID != "" && outreachClientSecret != "" && refreshToken != "" {
-		cbWithRefreshToken, err := NewWithRefreshToken(ctx, outreachClientID, outreachClientSecret, refreshToken)
+		cbWithRefreshToken, err := NewWithRefreshToken(ctx, outreachClientID, outreachClientSecret, refreshToken, baseURL)
 		if err != nil {
 			l.Error("error creating connector with refresh token", zap.Error(err))
 			return nil, nil, err
@@ -145,7 +148,7 @@ func New(ctx context.Context, config *cfg.Outreach, opts *cli.ConnectorOpts) (co
 
 	if accessToken == "" && refreshToken == "" && opts.TokenSource != nil {
 		tokenSource := opts.TokenSource
-		cbWithTokenSource, err := NewWithTokenSource(ctx, tokenSource)
+		cbWithTokenSource, err := NewWithTokenSource(ctx, tokenSource, baseURL)
 		if err != nil {
 			l.Error("error creating connector with token source", zap.Error(err))
 			return nil, nil, err

--- a/pkg/connector/resource_types.go
+++ b/pkg/connector/resource_types.go
@@ -4,9 +4,11 @@ import (
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
 )
 
+const userResourceTypeID = "user"
+
 // The user resource type is for all user objects from the database.
 var userResourceType = &v2.ResourceType{
-	Id:          "user",
+	Id:          userResourceTypeID,
 	DisplayName: "User",
 	Traits:      []v2.ResourceType_Trait{v2.ResourceType_TRAIT_USER},
 }

--- a/pkg/connector/teams.go
+++ b/pkg/connector/teams.go
@@ -163,7 +163,7 @@ func (b *teamBuilder) Grant(ctx context.Context, principal *v2.Resource, entitle
 	}
 	teamMembers = append(teamMembers, client.DataDetailPair{
 		Id:   userID,
-		Type: "user",
+		Type: userResourceTypeID,
 	})
 
 	rateLimitData, err = b.client.UpdateTeamMembers(ctx, teamID, teamMembers)

--- a/pkg/connector/users.go
+++ b/pkg/connector/users.go
@@ -196,7 +196,7 @@ func createNewUserInfo(accountInfo *v2.AccountInfo) (*client.NewUserBody, error)
 			Type       string                   `json:"type"` // The type should always be 'user'.
 			Attributes client.NewUserAttributes `json:"attributes"`
 		}{
-			Type: "user",
+			Type: userResourceTypeID,
 			Attributes: client.NewUserAttributes{
 				Email:     email,
 				FirstName: firstName,


### PR DESCRIPTION
## Summary

Adds the `--base-url` CLI flag to enable overriding the default API endpoint for testing purposes.

## Changes

- Added `BaseURLField` to configuration
- Updated client/connector to accept and use the base URL override
- When `--base-url` is provided, it takes precedence over the default API URL

## Files Modified

```
pkg/config/conf.gen.go,pkg/config/config.go,pkg/connector/client/client.go,pkg/connector/client/helper.go,pkg/connector/connector.go
```

## Testing

The connector can now be tested against mock servers:
```bash
baton-outreach --base-url http://localhost:8080 [other-flags]
```

## Related

Part of the Connector Testability initiative.