### PR TITLE
Migrate off deprecated trait profile/status attributes

### DIFF
--- a/pkg/connector/profiles.go
+++ b/pkg/connector/profiles.go
@@ -137,9 +137,8 @@ func parseIntoProfileResource(prof client.Profile) (*v2.Resource, error) {
 		"is_admin":   prof.Attributes.IsAdmin,
 	}
 
-	profileTraits := []rs.RoleTraitOption{
-		rs.WithRoleProfile(profile),
-	}
+	profileTraits := []rs.RoleTraitOption{}
+	resourceOptions = append(resourceOptions, rs.WithResourceProfile(profile))
 
 	ret, err := rs.NewRoleResource(
 		prof.Attributes.Name,

--- a/pkg/connector/teams.go
+++ b/pkg/connector/teams.go
@@ -226,15 +226,14 @@ func parseIntoTeamResource(team client.Team) (*v2.Resource, error) {
 		"updated_at": team.Attributes.UpdatedAt,
 	}
 
-	groupTraits := []rs.GroupTraitOption{
-		rs.WithGroupProfile(profile),
-	}
+	groupTraits := []rs.GroupTraitOption{}
 
 	ret, err := rs.NewGroupResource(
 		team.Attributes.Name,
 		teamResourceType,
 		team.Id,
 		groupTraits,
+		rs.WithResourceProfile(profile),
 	)
 	if err != nil {
 		return nil, err

--- a/pkg/connector/users.go
+++ b/pkg/connector/users.go
@@ -264,8 +264,6 @@ func parseIntoUserResource(user client.User) (*v2.Resource, error) {
 		rs.WithLastLogin(user.Attributes.LastSignInAt),
 		rs.WithEmail(primaryEmail, true),
 		rs.WithUserLogin(primaryEmail),
-		rs.WithUserProfile(profile),
-		rs.WithStatus(userStatus),
 	)
 
 	ret, err := rs.NewUserResource(
@@ -273,6 +271,8 @@ func parseIntoUserResource(user client.User) (*v2.Resource, error) {
 		userResourceType,
 		user.Id,
 		userTraits,
+		rs.WithResourceProfile(profile),
+		rs.WithResourceStatus(v2.Status_ResourceStatus(userStatus), ""),
 	)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
baton-sdk v0.20.6 moved `profile`, `status`, and `created_at` off the trait
messages onto attributes on `Resource`, deprecating the trait-level options and
getters. staticcheck flags every remaining call with `SA1019`, so `verify / lint`
is red on `main`.

This migrates the connector to the resource-level API:

- `With{User,Group,Role,App}Profile` -> `WithResourceProfile`
- `WithStatus` / `WithDetailedStatus` -> `WithResourceStatus`
- `WithCreatedAt` / `WithSecretCreatedAt` -> `WithResourceCreatedAt`
- trait `GetProfile()` / `GetStatus()` reads -> the equivalent read on the resource

The option type changes from a `*TraitOption` to a `ResourceOption`, so the calls
move out of the trait slice and into the variadic tail of the `New*Resource` call.
The two status enums are numerically identical, so the values map 1:1. Non-deprecated
trait data (login, aliases, emails, secret type/expiry) is untouched.

No behavioural change intended: the deprecated options already populated the
resource-level fields. `golangci-lint run ./...` reports 0 issues after this
change, and the package tests pass.
