### PR TITLE
[CE-1178] Guard profile grant emission behind WillSyncResourceType

### DIFF
--- a/baton_capabilities.json
+++ b/baton_capabilities.json
@@ -35,6 +35,11 @@
         "displayName": "User",
         "traits": [
           "TRAIT_USER"
+        ],
+        "annotations": [
+          {
+            "@type": "type.googleapis.com/c1.connector.v2.SkipEntitlements"
+          }
         ]
       },
       "capabilities": [

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -18,12 +18,16 @@ import (
 
 type Connector struct {
 	client *client.OutreachClient
+	// skipProfileResourceType reports whether profile is excluded from the sync
+	// filter. Named for the skip condition so the zero value is safe: a
+	// zero-value Connector{} is used to generate the capability set.
+	skipProfileResourceType bool
 }
 
 // ResourceSyncers returns a ResourceSyncer for each resource type that should be synced from the upstream service.
 func (d *Connector) ResourceSyncers(_ context.Context) []connectorbuilder.ResourceSyncerV2 {
 	return []connectorbuilder.ResourceSyncerV2{
-		newUserBuilder(d.client),
+		newUserBuilder(d.client, d.skipProfileResourceType),
 		newTeamBuilder(d.client),
 		newProfileBuilder(d.client),
 	}
@@ -118,6 +122,14 @@ func New(ctx context.Context, config *cfg.Outreach, opts *cli.ConnectorOpts) (co
 	var cb *Connector
 	l := ctxzap.Extract(ctx)
 
+	// nil opts means no SDK-supplied token source and no sync filter.
+	var tokenSource oauth2.TokenSource
+	skipProfileResourceType := false
+	if opts != nil {
+		tokenSource = opts.TokenSource
+		skipProfileResourceType = !opts.WillSyncResourceType(ProfileResourceTypeID)
+	}
+
 	accessToken := config.AccessToken
 	if accessToken != "" {
 		cbWithAccessToken, err := NewWithAccessToken(ctx, accessToken)
@@ -143,8 +155,7 @@ func New(ctx context.Context, config *cfg.Outreach, opts *cli.ConnectorOpts) (co
 		cb = cbWithRefreshToken
 	}
 
-	if accessToken == "" && refreshToken == "" && opts.TokenSource != nil {
-		tokenSource := opts.TokenSource
+	if accessToken == "" && refreshToken == "" && tokenSource != nil {
 		cbWithTokenSource, err := NewWithTokenSource(ctx, tokenSource)
 		if err != nil {
 			l.Error("error creating connector with token source", zap.Error(err))
@@ -157,6 +168,7 @@ func New(ctx context.Context, config *cfg.Outreach, opts *cli.ConnectorOpts) (co
 	if cb == nil {
 		return nil, nil, fmt.Errorf("connector initialization failed")
 	}
+	cb.skipProfileResourceType = skipProfileResourceType
 
 	return cb, nil, nil
 }

--- a/pkg/connector/resource_types.go
+++ b/pkg/connector/resource_types.go
@@ -5,6 +5,8 @@ import (
 )
 
 // The user resource type is for all user objects from the database.
+// newUserBuilder clones this and adds SkipEntitlements, or
+// SkipEntitlementsAndGrants when profile isn't synced.
 var userResourceType = &v2.ResourceType{
 	Id:          "user",
 	DisplayName: "User",
@@ -17,8 +19,11 @@ var teamResourceType = &v2.ResourceType{
 	Traits:      []v2.ResourceType_Trait{v2.ResourceType_TRAIT_GROUP},
 }
 
+// ProfileResourceTypeID is referenced when gating cross-type profile grants.
+const ProfileResourceTypeID = "profile"
+
 var profileResourceType = &v2.ResourceType{
-	Id:          "profile",
+	Id:          ProfileResourceTypeID,
 	DisplayName: "Profile",
 	Traits:      []v2.ResourceType_Trait{v2.ResourceType_TRAIT_ROLE},
 }

--- a/pkg/connector/users.go
+++ b/pkg/connector/users.go
@@ -14,14 +14,16 @@ import (
 	rs "github.com/conductorone/baton-sdk/pkg/types/resource"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
 )
 
 type userBuilder struct {
-	client *client.OutreachClient
+	client       *client.OutreachClient
+	resourceType *v2.ResourceType
 }
 
 func (b *userBuilder) ResourceType(_ context.Context) *v2.ResourceType {
-	return userResourceType
+	return b.resourceType
 }
 
 func (b *userBuilder) List(ctx context.Context, parentResourceID *v2.ResourceId, attr rs.SyncOpAttrs) ([]*v2.Resource, *rs.SyncOpResults, error) {
@@ -281,9 +283,23 @@ func parseIntoUserResource(user client.User) (*v2.Resource, error) {
 	return ret, nil
 }
 
-func newUserBuilder(c *client.OutreachClient) *userBuilder {
+// newUserBuilder returns the user syncer. Users have no entitlements of their
+// own, and their only grants are cross-type profile grants, so when profile is
+// excluded from the sync the grants pass is skipped too -- that also avoids the
+// per-user profile lookup whose result would be discarded.
+func newUserBuilder(c *client.OutreachClient, skipProfileResourceType bool) *userBuilder {
+	rt := proto.Clone(userResourceType).(*v2.ResourceType)
+	annos := annotations.Annotations(rt.GetAnnotations())
+	if skipProfileResourceType {
+		annos.Update(&v2.SkipEntitlementsAndGrants{})
+	} else {
+		annos.Update(&v2.SkipEntitlements{})
+	}
+	rt.Annotations = annos
+
 	return &userBuilder{
-		client: c,
+		client:       c,
+		resourceType: rt,
 	}
 }
 

--- a/pkg/connector/users_guard_test.go
+++ b/pkg/connector/users_guard_test.go
@@ -1,0 +1,58 @@
+package connector
+
+import (
+	"context"
+	"testing"
+
+	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
+	"google.golang.org/protobuf/proto"
+)
+
+func hasAnno(rt *v2.ResourceType, msg proto.Message) bool {
+	for _, a := range rt.GetAnnotations() {
+		if a.MessageIs(msg) {
+			return true
+		}
+	}
+	return false
+}
+
+// The user type's only grants are cross-type profile grants, so when profile is
+// excluded the whole grants pass is skipped -- which also avoids the per-user
+// profile lookup that would otherwise be discarded.
+func TestUserResourceType_SkipAnnotation(t *testing.T) {
+	inScope := newUserBuilder(nil, false).ResourceType(context.Background())
+	if !hasAnno(inScope, &v2.SkipEntitlements{}) || hasAnno(inScope, &v2.SkipEntitlementsAndGrants{}) {
+		t.Fatalf("profile in scope: want SkipEntitlements only, got %v", inScope.GetAnnotations())
+	}
+
+	filtered := newUserBuilder(nil, true).ResourceType(context.Background())
+	if !hasAnno(filtered, &v2.SkipEntitlementsAndGrants{}) {
+		t.Fatalf("profile filtered: want SkipEntitlementsAndGrants, got %v", filtered.GetAnnotations())
+	}
+
+	// Both branches annotate, so a dropped proto.Clone would leak either one
+	// onto the shared package-level value.
+	if hasAnno(userResourceType, &v2.SkipEntitlementsAndGrants{}) || hasAnno(userResourceType, &v2.SkipEntitlements{}) {
+		t.Fatal("package-level userResourceType was mutated")
+	}
+}
+
+// A zero-value Connector{} is used to generate the capability set, bypassing
+// New; it must report the unfiltered capabilities.
+func TestZeroValueConnector_DoesNotSkipGrants(t *testing.T) {
+	var found bool
+	for _, s := range (&Connector{}).ResourceSyncers(context.Background()) {
+		rt := s.ResourceType(context.Background())
+		if rt.GetId() != userResourceType.Id {
+			continue
+		}
+		found = true
+		if hasAnno(rt, &v2.SkipEntitlementsAndGrants{}) {
+			t.Fatal("zero-value Connector advertised SkipEntitlementsAndGrants")
+		}
+	}
+	if !found {
+		t.Fatal("user syncer missing from ResourceSyncers; nothing was asserted")
+	}
+}


### PR DESCRIPTION
Closes CE-1178.

`userBuilder.Grants` emits exactly one kind of grant — a cross-type grant against the user's profile. When `profile` is excluded from the sync, that grant would point at a resource type that was never synced.

### Annotation shape

The user type has no entitlements of its own and exactly one grant target, so the annotation **is** the guard:

- `profile` in scope → `SkipEntitlements`
- `profile` excluded → `SkipEntitlementsAndGrants`

There is deliberately **no** redundant `skipProfileResourceType` check inside `Grants`: with a single target the SDK never calls `Grants` in the excluded case, so such a check would be unreachable. That also means the per-user profile lookup is skipped entirely rather than performed and discarded.

### Incidental nil-safety fix

`New` already dereferenced `opts.TokenSource` unconditionally, so a nil `*cli.ConnectorOpts` would panic before reaching any new code. `TokenSource` and the new sync-filter read now go through a single nil check, which is what makes the `opts != nil` guard meaningful rather than decorative.

`baton_capabilities.json` is regenerated for the new annotation.

### Testing

- `TestUserResourceType_SkipAnnotation` covers both branches and asserts the package-level `userResourceType` is never mutated by either.
- `TestZeroValueConnector_DoesNotSkipGrants` guards the capabilities-factory path and fails if the user syncer is dropped, rather than passing vacuously.
- `go build`, `go vet`, `go test ./...` pass; `golangci-lint` matches the 4 pre-existing `staticcheck` issues on `main`, none added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)